### PR TITLE
fix(#7): Group Connection doesn't handle count-only queries

### DIFF
--- a/src/Epam.GraphQL/Sorters/Implementations/SortingHelpers.cs
+++ b/src/Epam.GraphQL/Sorters/Implementations/SortingHelpers.cs
@@ -84,7 +84,7 @@ namespace Epam.GraphQL.Sorters.Implementations
 
             if (sortFields.Any(f => !(f.Item1?.IsGroupable ?? false)))
             {
-                throw new ExecutionError($"Cannot find field(s) for sorting: {string.Join(", ", sorting.Select(o => o.Field))}");
+                throw new ExecutionError($"Cannot sort by the following fields: {string.Join(", ", sorting.Select(o => $"`{o.Field}`"))}. Consider making them groupable.");
             }
 
             var subFields = context.GetGroupConnectionQueriedFields()


### PR DESCRIPTION
Actually it has been fixed by #22 (which closes #8);
Added unit test for this case; Improved exception message